### PR TITLE
Replace update-tags (which has no effect) with update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ async function run() {
 
     if (!foundInCache) {
       if (emArgs.updateTags) {
-        await exec.exec(`${emsdk} update-tags`);
+        await exec.exec(`${emsdk} update`);
       }
 
       await exec.exec(`${emsdk} install ${emArgs.version}`);


### PR DESCRIPTION
I encountered the following error in my action whenever I set an explicit version:
```
/home/runner/work/_temp/8da50650-0692-4b2a-b2ce-6bb33e5d99ea/emsdk-master/emsdk update-tags
`update-tags` is not longer needed.  To install the latest tot release just run `install tot`
/home/runner/work/_temp/8da50650-0692-4b2a-b2ce-6bb33e5d99ea/emsdk-master/emsdk install 2.0.29
Error: No tool or SDK found by name '2.0.29'.
Error: The process '/home/runner/work/_temp/8da50650-0692-4b2a-b2ce-6bb33e5d99ea/emsdk-master/emsdk' failed with exit code 1
```

<details>
<summary>My workflow config</summary>
<pre><code>
    - uses: mymindstorm/setup-emsdk@v9
      with:
        version: '2.0.29'
        update-tags: true
        actions-cache-folder: 'emsdk-cache'
</code></pre>
</details>

Changing `emsdk update-tag` to `emsdk update` fixed it for me, but I'm not 100% sure if that's the right solution. It does seem like `update-tags` is effectively gone though: https://github.com/emscripten-core/emsdk/pull/738.

If this switch to `update` is the way you want to go, I'd be happy to do the work to get this PR merge-ready. I only had to change the implementation to workaround the issue, but I imagine we'd at least want to update the docs too. One open question is whether changing the name in the action input would cause any compatibility concerns.