### PR TITLE
fix Error: Unable to reserve cache with key

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -64,7 +64,7 @@ function run() {
             if (emArgs.version !== "latest" && emArgs.version !== "tot" && emArgs.noCache === "false" && !emArgs.actionsCacheFolder) {
                 emsdkFolder = yield tc.find('emsdk', emArgs.version, os.arch());
             }
-            const cacheKey = `${emArgs.version}-${os.platform()}-${os.arch()}-master`;
+            const cacheKey = `emsdk-${emArgs.version}-${os.platform()}-${os.arch()}-master`;
             if (emArgs.actionsCacheFolder && process.env.GITHUB_WORKSPACE) {
                 const fullCachePath = path.join(process.env.GITHUB_WORKSPACE, emArgs.actionsCacheFolder);
                 try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function run() {
       emsdkFolder = await tc.find('emsdk', emArgs.version, os.arch());
     }
 
-    const cacheKey = `${emArgs.version}-${ os.platform() }-${os.arch()}-master`;
+    const cacheKey = `emsdk-${emArgs.version}-${ os.platform() }-${os.arch()}-master`;
     if (emArgs.actionsCacheFolder && process.env.GITHUB_WORKSPACE) {
       const fullCachePath = path.join(process.env.GITHUB_WORKSPACE, emArgs.actionsCacheFolder);
       try {


### PR DESCRIPTION
Hi, I found the default key may fail
when I use cache

```
Run mymindstorm/setup-emsdk@v12
  with:
    version: [3](https://github.com/PikachuHy/pscm/actions/runs/4711124540/jobs/8355298278?pr=11#step:5:3).1.35
    actions-cache-folder: emsdk-cache
    no-install: false
    no-cache: false
    update: false
    update-tags: false
  env:
    EM_VERSION: 3.1.3[5](https://github.com/PikachuHy/pscm/actions/runs/4711124540/jobs/8355298278?pr=11#step:5:5)
    EM_CACHE_FOLDER: emsdk-cache
Warning: No cached files found at path "/home/runner/work/pscm/pscm/emsdk-cache" - downloading and caching emsdk.

...

Setting environment variables:
PATH = /home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main:/home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main/upstream/emscripten:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
EMSDK = /home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main
EMSDK_NODE = /home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main/node/15.14.0_64bit/bin/node
export PATH="/home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main:/home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main/upstream/emscripten:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games";
export EMSDK="/home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main";
export EMSDK_NODE="/home/runner/work/_temp/49cc915a-ec90-4882-9c4d-e5c4b448fc4c/emsdk-main/node/15.14.0_64bit/bin/node";
Error: Unable to reserve cache with key 3.1.35-linux-x64-master, another job may be creating this cache.
```

see https://github.com/PikachuHy/pscm/actions/runs/4711124540/jobs/8355298278?pr=11

I fix by adding `emsdk` prefix
